### PR TITLE
Update licensing to be The maxCPUID Contributors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,1 @@
+Chris Blume cblume@google.com

--- a/Code/TranslationUnits/EntryPoint.cpp
+++ b/Code/TranslationUnits/EntryPoint.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016, Chris Blume. All rights reserved.
+// Copyright 2016, The maxCPUID Contributors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2016, Chris Blume
+Copyright 2016, The maxCPUID Contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -11,9 +11,9 @@ notice, this list of conditions and the following disclaimer.
 copyright notice, this list of conditions and the following disclaimer
 in the documentation and/or other materials provided with the
 distribution.
-    * Neither the name of Chris Blume nor the
-names of its contributors may be used to endorse or promote products
-derived from this software without specific prior written permission.
+    * Neither the name of maxCPUID nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT


### PR DESCRIPTION
Currently, the copyright is held by Chris Blume.
This is correct for the time being. But it is not inviting
to others who may want to contribute to the project.

Instead, create an AUTHORS file where contributors can
add themselves and change the copyright ownership to
The maxCPUID Contributors.

Issue #10 